### PR TITLE
Add shadow alias for elevation

### DIFF
--- a/src/lib/formatModule.ts
+++ b/src/lib/formatModule.ts
@@ -1,14 +1,21 @@
 import { kebab } from 'case';
 import mapObject from 'map-obj';
-import type { PollenModule } from '../types';
+import type { ModuleName, PollenModule } from '../types';
+
+const ALIAS_MAP: ReadonlyMap<ModuleName, string[]> = new Map([
+  ['elevation', ['shadow']],
+]);
 
 export function formatModule(module: PollenModule) {
   return Object.keys(module)
-    .map((family) => {
-      return mapObject(module[family as keyof typeof module], (key, value) => [
-        `--${kebab(family)}-${kebab(String(key))}`,
+    .flatMap((family) => {
+      const candidates = [family];
+      const aliases = ALIAS_MAP.get(family as keyof typeof module);
+      aliases && candidates.push(...aliases);
+      return candidates.map((candidate) => mapObject(module[family as keyof typeof module], (key, value) => [
+        `--${kebab(candidate)}-${kebab(String(key))}`,
         value
-      ]);
+      ]));
     })
     .reduce((acc, cur) => ({ ...acc, ...cur }), {});
 }

--- a/src/modules/ui.ts
+++ b/src/modules/ui.ts
@@ -58,20 +58,6 @@ export default {
   },
 
   /**
-   * Shadow
-   * Alias for elevation
-   */
-  shadow: {
-    1: '0 1px 2px 0 rgba(0, 0, 0, 0.05)',
-    2: '0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06)',
-    3: '0 4px 6px -2px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.06)',
-    4: '0 12px 16px -4px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)',
-    5: '0 20px 24px -4px rgba(0, 0, 0, 0.1), 0 8px 8px -4px rgba(0, 0, 0, 0.04)',
-    6: '0 24px 48px -12px rgba(0, 0, 0, 0.25)',
-    7: '0 32px 64px -12px rgba(0, 0, 0, 0.2)'
-  },
-
-  /**
    * Motion easing curves
    * Applied in transitions and animations
    * Inspired by Material Design https://material.io/design/motion/speed.html#easing

--- a/src/modules/ui.ts
+++ b/src/modules/ui.ts
@@ -58,6 +58,20 @@ export default {
   },
 
   /**
+   * Shadow
+   * Alias for elevation
+   */
+  shadow: {
+    1: '0 1px 2px 0 rgba(0, 0, 0, 0.05)',
+    2: '0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06)',
+    3: '0 4px 6px -2px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.06)',
+    4: '0 12px 16px -4px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)',
+    5: '0 20px 24px -4px rgba(0, 0, 0, 0.1), 0 8px 8px -4px rgba(0, 0, 0, 0.04)',
+    6: '0 24px 48px -12px rgba(0, 0, 0, 0.25)',
+    7: '0 32px 64px -12px rgba(0, 0, 0, 0.2)'
+  },
+
+  /**
    * Motion easing curves
    * Applied in transitions and animations
    * Inspired by Material Design https://material.io/design/motion/speed.html#easing

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import modules from './modules';
-type ModuleName = keyof typeof modules;
+export type ModuleName = keyof typeof modules;
 
 export type PollenModule = {
   [module in ModuleName]: { [key: string]: string | number };


### PR DESCRIPTION
@madeleineostoja I've gone with the naive approach for #64 here 🙂

I thought it might be cool to provide some kind of "alias" map to `formatModule`, that way things can easily be aliased and you don't need to worry about duplication. For this naive solution, any change to "elevation" would require "shadow" to be updated too. I'm happy to explore that some more if you think that's a better way forward 👍🏼 

Approach 1: https://github.com/heybokeh/pollen/pull/65/commits/451c93e796f8133ae182c1e56ac55bd20549fb24 (naive)
Approach 2: https://github.com/heybokeh/pollen/pull/65/commits/40cdc51620c51394e6eb0fafa60c7f7e3e608cb1 (more flexible/scalable)